### PR TITLE
add context, NSKeyValueObservingOptions param for NSObject+YYAddForKVO.h

### DIFF
--- a/YYCategories/Foundation/NSObject+YYAddForKVO.h
+++ b/YYCategories/Foundation/NSObject+YYAddForKVO.h
@@ -34,6 +34,27 @@ NS_ASSUME_NONNULL_BEGIN
                              block:(void (^)(id _Nonnull obj, id _Nonnull oldVal, id _Nonnull newVal))block;
 
 /**
+ Registers a block to receive KVO notifications for the specified key-path
+ relative to the receiver.
+ 
+ @discussion The block and block captured objects are retained. Call
+ `removeObserverBlocksForKeyPath:` or `removeObserverBlocks` to release.
+ 
+ @param keyPath The key path, relative to the receiver, of the property to
+ observe. This value must not be nil.
+ 
+ @param options Options for use with -addObserverBlockForKeyPath:options:context:block:.
+ 
+ @param context When the same observer is registered for the same key path multiple times, with different context pointers each time.
+ 
+ @param block   The block to register for KVO notifications.
+ */
+- (void)addObserverBlockForKeyPath:(NSString*)keyPath
+                           options:(NSKeyValueObservingOptions)options
+                           context:(nullable void *)context
+                             block:(void (^)(id _Nonnull obj, id _Nonnull oldVal, id _Nonnull newVal))block;
+
+/**
  Stops all blocks (associated by `addObserverBlockForKeyPath:block:`) from
  receiving change notifications for the property specified by a given key-path 
  relative to the receiver, and release these blocks.

--- a/YYCategories/Foundation/NSObject+YYAddForKVO.m
+++ b/YYCategories/Foundation/NSObject+YYAddForKVO.m
@@ -64,6 +64,22 @@ static const int block_key;
 @implementation NSObject (YYAddForKVO)
 
 - (void)addObserverBlockForKeyPath:(NSString *)keyPath block:(void (^)(__weak id obj, id oldVal, id newVal))block {
+    
+    [self addObserverWithKeyPath:keyPath options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:NULL block:block];
+}
+
+- (void)addObserverBlockForKeyPath:(NSString*)keyPath
+                           options:(NSKeyValueObservingOptions)options
+                           context:(nullable void *)context
+                             block:(void (^)(id _Nonnull obj, id _Nonnull oldVal, id _Nonnull newVal))block {
+    [self addObserverWithKeyPath:keyPath options:options context:context block:block];
+}
+
+- (void)addObserverWithKeyPath:(NSString *)keyPath
+                      options:(NSKeyValueObservingOptions)options
+                      context:(nullable void *)context
+                        block:(void (^)(__weak id obj, id oldVal, id newVal))block {
+    
     if (!keyPath || !block) return;
     _YYNSObjectKVOBlockTarget *target = [[_YYNSObjectKVOBlockTarget alloc] initWithBlock:block];
     NSMutableDictionary *dic = [self _yy_allNSObjectObserverBlocks];
@@ -73,7 +89,7 @@ static const int block_key;
         dic[keyPath] = arr;
     }
     [arr addObject:target];
-    [self addObserver:target forKeyPath:keyPath options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:NULL];
+    [self addObserver:target forKeyPath:keyPath options:options context:context];
 }
 
 - (void)removeObserverBlocksForKeyPath:(NSString *)keyPath {

--- a/YYCategories/Foundation/NSTimer+YYAdd.m
+++ b/YYCategories/Foundation/NSTimer+YYAdd.m
@@ -25,11 +25,15 @@ YYSYNTH_DUMMY_CLASS(NSTimer_YYAdd)
 }
 
 + (NSTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)seconds block:(void (^)(NSTimer *timer))block repeats:(BOOL)repeats {
-    return [NSTimer scheduledTimerWithTimeInterval:seconds target:self selector:@selector(_yy_ExecBlock:) userInfo:[block copy] repeats:repeats];
+    NSTimer * timer = [NSTimer scheduledTimerWithTimeInterval:seconds target:self selector:@selector(_yy_ExecBlock:) userInfo:[block copy] repeats:repeats];
+    [[NSRunLoop currentRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+    return timer;
 }
 
 + (NSTimer *)timerWithTimeInterval:(NSTimeInterval)seconds block:(void (^)(NSTimer *timer))block repeats:(BOOL)repeats {
-    return [NSTimer timerWithTimeInterval:seconds target:self selector:@selector(_yy_ExecBlock:) userInfo:[block copy] repeats:repeats];
+    NSTimer * timer = [NSTimer timerWithTimeInterval:seconds target:self selector:@selector(_yy_ExecBlock:) userInfo:[block copy] repeats:repeats];
+    [[NSRunLoop currentRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+    return timer;
 }
 
 @end


### PR DESCRIPTION
add context, NSKeyValueObservingOptions param for NSObject+YYAddForKVO.h

在使用Categories的时候，使用监听发现参数被写死了，我想使用options还有context参数。因为有keyPath相同但是context不同的情况，所以提交这个Request.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibireme/yycategories/20)

<!-- Reviewable:end -->
