### PR TITLE
suppress the xcode documentation comments warning

### DIFF
--- a/YYCategories/Foundation/NSString+YYAdd.h
+++ b/YYCategories/Foundation/NSString+YYAdd.h
@@ -117,7 +117,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Returns an NSString from base64 encoded string.
- @param base64Encoding The encoded string.
+ @param base64EncodedStringyy The encoded string.
  */
 + (nullable NSString *)stringWithBase64EncodedString:(NSString *)base64EncodedString;
 
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Escape commmon HTML to Entity.
- Example: "a<b" will be escape to "a&lt;b".
+ Example: "a>b" will be escape to "a&gt;b".
  */
 - (NSString *)stringByEscapingHTML;
 

--- a/YYCategories/Quartz/YYCGUtilities.h
+++ b/YYCategories/Quartz/YYCGUtilities.h
@@ -107,7 +107,7 @@ NSString *YYUIViewContentModeToCAGravity(UIViewContentMode contentMode);
 
 
 /**
- Returns a rectangle to fit the @param rect with specified content mode.
+ Returns a rectangle to fit the param rect with specified content mode.
  
  @param rect The constrant rect
  @param size The content size

--- a/YYCategories/UIKit/UIDevice+YYAdd.h
+++ b/YYCategories/UIKit/UIDevice+YYAdd.h
@@ -106,7 +106,7 @@ typedef NS_OPTIONS(NSUInteger, YYNetworkTrafficType) {
      _lastTime = time;
  
  
- @param type traffic types
+ @param types traffic types
  @return bytes counter.
  */
 - (uint64_t)getNetworkTrafficBytes:(YYNetworkTrafficType)types;

--- a/YYCategories/YYCategoriesMacro.h
+++ b/YYCategories/YYCategoriesMacro.h
@@ -201,8 +201,8 @@ static inline CFTypeRef YYCFAutorelease(CFTypeRef CF_RELEASES_ARGUMENT arg) {
 
 /**
  Profile time cost.
- @param ^block     code to benchmark
- @param ^complete  code time cost (millisecond)
+ @param block     code to benchmark
+ @param complete  code time cost (millisecond)
  
  Usage:
     YYBenchmark(^{


### PR DESCRIPTION
before this issue fixed,you can use the code snippet below to suppress the warning when you import the "YYCategories.h" header (better to do this in your prefix header file):
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wdocumentation"

#import "YYCategories.h"

#pragma clang pop